### PR TITLE
loosen the type of AWSPreparedRequest's body argument

### DIFF
--- a/botocore-stubs/awsrequest.pyi
+++ b/botocore-stubs/awsrequest.pyi
@@ -1,6 +1,7 @@
+import io
 from collections.abc import MutableMapping
 from logging import Logger
-from typing import Any, Dict, Iterator, Mapping, Optional, Type, TypeVar
+from typing import Any, Dict, Iterator, Mapping, Optional, Type, TypeVar, Union
 
 from botocore.compat import HTTPHeaders as HTTPHeaders
 from botocore.compat import HTTPResponse as HTTPResponse
@@ -58,7 +59,7 @@ class AWSPreparedRequest:
         method: str,
         url: str,
         headers: HTTPHeaders,
-        body: str,
+        body: Union[str, bytes, bytearray, io.IOBase, None],
         stream_output: bool,
     ) -> None:
         self.method: str


### PR DESCRIPTION
Referencing the implementation of of its reset_stream() method shows they're expecting to handle a broad range of body objects

https://github.com/boto/botocore/blob/4b728545d43ff70287ae1d0dce42e995790e6b85/botocore/awsrequest.py#L518