### PR TITLE
Convert `license` to `license` + `license-files`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,8 @@ version = "1.38.46"
 requires-python = ">=3.9"
 description = "Type annotations and code completion for botocore"
 authors = [{ name = "Vlad Emelianov", email = "vlad.emelianov.nz@gmail.com" }]
-license = { file = "LICENSE" }
+license = "MIT"
+license-files = ["LICENSE"]
 readme = "README.md"
 keywords = ["botocore", "type-annotations", "pyright", "mypy", "boto3"]
 classifiers = [


### PR DESCRIPTION
Convert the deprecated license format in pyproject.toml to the new format with license (SPDX identifier) and license-files.

For details see https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license-and-license-files